### PR TITLE
Don't deploy debug binaries to /usr/local/bin

### DIFF
--- a/src/k7/deploy/k7-install-node.yaml
+++ b/src/k7/deploy/k7-install-node.yaml
@@ -301,6 +301,7 @@
       loop: "{{ firecracker_binaries.files }}"
       when: >
         'firecracker' in item.path and
+        not item.path.endswith('.debug') and
         lookup('pipe', 'file ' ~ item.path) is search('ELF .* executable')
 
     - name: Find jailer binary
@@ -319,6 +320,7 @@
       loop: "{{ jailer_binaries.files }}"
       when: >
         'jailer' in item.path and
+        not item.path.endswith('.debug') and
         lookup('pipe', 'file ' ~ item.path) is search('ELF .* executable')
 
     - name: Remove bundled Firecracker & jailer


### PR DESCRIPTION
On ARM, the k7 install command was failing at the firecracker --version check step.

The cause was that the ansible script would sometimes install the debug binary (`/opt/firecracker/firecracker-v1.13.1-aarch64.debug`) to /usr/local/bin/firecracker instead of the non-debug binary.

On ARM, the debug binary is filled with udf #0 instructions, so trying to run it immediately crashes.

The debug binary is an ELF binary, so ansible installs both to /usr/local/bin, and the last one wins.

The fix here is to exclude ELF files ending with `.debug`. In theory this could affect the jailer installation as well.

## Logs / extra info
```
admin@ubuntu:~/k7$ k7 install
...
admin@ubuntu:~/k7$ /usr/local/bin/firecracker
Illegal instruction (core dumped)
admin@ubuntu:~/k7$ diff /opt/firecracker/firecracker-v1.13.1-aarch64.debug /usr/local/bin/firecracker
admin@ubuntu:~/k7$ diff /opt/firecracker/firecracker-v1.13.1-aarch64 /usr/local/bin/firecracker
Binary files /opt/firecracker/firecracker-v1.13.1-aarch64 and /usr/local/bin/firecracker differ
```

GDB:

```gdb
admin@ubuntu:/opt/firecracker$  gdb -q --args /usr/local/bin/firecracker
Reading symbols from /usr/local/bin/firecracker...
(gdb) symbol-file /opt/firecracker/firecracker-v1.13.1-aarch64.debug
Load new symbol table from "/opt/firecracker/firecracker-v1.13.1-aarch64.debug"? (y or n) y
Reading symbols from /opt/firecracker/firecracker-v1.13.1-aarch64.debug...
(gdb) run
Starting program: /usr/local/bin/firecracker 

Program received signal SIGILL, Illegal instruction.
0x000000000040d658 in _start ()
(gdb) disassemble /r $pc-8, $pc+16
Dump of assembler code from 0x40d650 to 0x40d668:
   0x000000000040d650 <__init_cpu_features+72>:	00000000	udf	#0
   0x000000000040d654 <__init_cpu_features+76>:	00000000	udf	#0
=> 0x000000000040d658 <_start+0>:	00000000	udf	#0
   0x000000000040d65c <_start+4>:	00000000	udf	#0
   0x000000000040d660 <_start+8>:	00000000	udf	#0
   0x000000000040d664 <_start+12>:	00000000	udf	#0
```

Logs:

```
TASK [Copy firecracker binary to final path (only if ELF)] *********************
changed: [localhost] => (item={'path': '/opt/firecracker/firecracker-v1.13.1-aarch64', 'mode': '0755', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 645722313, 'gid': 600260513, 'size': 2866368, 'inode': 848419, 'dev': 64769, 'nlink': 1, 'atime': 1761515925.636994, 'mtime': 1756736432.0, 'ctime': 1761515925.0259871, 'gr_name': '', 'pw_name': '', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False}) => {"ansible_loop_var": "item", "changed": true, "checksum": "d10370f3d9376cd407bc441f8370186e0f59622f", "dest": "/usr/local/bin/firecracker", "gid": 0, "group": "root", "item": {"atime": 1761515925.636994, "ctime": 1761515925.0259871, "dev": 64769, "gid": 600260513, "gr_name": "", "inode": 848419, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0755", "mtime": 1756736432.0, "nlink": 1, "path": "/opt/firecracker/firecracker-v1.13.1-aarch64", "pw_name": "", "rgrp": true, "roth": true, "rusr": true, "size": 2866368, "uid": 645722313, "wgrp": false, "woth": false, "wusr": true, "xgrp": true, "xoth": true, "xusr": true}, "md5sum": "d41bdec5df4e9c1db98bf0a0b3eb634d", "mode": "0755", "owner": "root", "size": 2866368, "src": "/opt/firecracker/firecracker-v1.13.1-aarch64", "state": "file", "uid": 0}
skipping: [localhost] => (item={'path': '/opt/firecracker/firecracker_spec-v1.13.1.yaml', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 645722313, 'gid': 600260513, 'size': 43580, 'inode': 848417, 'dev': 64769, 'nlink': 1, 'atime': 1761515925.739995, 'mtime': 1756736432.0, 'ctime': 1761515924.999987, 'gr_name': '', 'pw_name': '', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})  => {"ansible_loop_var": "item", "changed": false, "false_condition": "'firecracker' in item.path and lookup('pipe', 'file ' ~ item.path) is search('ELF .* executable')\n", "item": {"atime": 1761515925.739995, "ctime": 1761515924.999987, "dev": 64769, "gid": 600260513, "gr_name": "", "inode": 848417, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1756736432.0, "nlink": 1, "path": "/opt/firecracker/firecracker_spec-v1.13.1.yaml", "pw_name": "", "rgrp": true, "roth": true, "rusr": true, "size": 43580, "uid": 645722313, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, "skip_reason": "Conditional result was False"}
changed: [localhost] => (item={'path': '/opt/firecracker/firecracker-v1.13.1-aarch64.debug', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 645722313, 'gid': 600260513, 'size': 2474824, 'inode': 848422, 'dev': 64769, 'nlink': 1, 'atime': 1761515925.746995, 'mtime': 1756736432.0, 'ctime': 1761515925.0369873, 'gr_name': '', 'pw_name': '', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False}) => {"ansible_loop_var": "item", "changed": true, "checksum": "7af1f1740e93bebf5a17fa5ad4291013688089df", "dest": "/usr/local/bin/firecracker", "gid": 0, "group": "root", "item": {"atime": 1761515925.746995, "ctime": 1761515925.0369873, "dev": 64769, "gid": 600260513, "gr_name": "", "inode": 848422, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1756736432.0, "nlink": 1, "path": "/opt/firecracker/firecracker-v1.13.1-aarch64.debug", "pw_name": "", "rgrp": true, "roth": true, "rusr": true, "size": 2474824, "uid": 645722313, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, "md5sum": "4349d4b8c74e94e745618344b356229b", "mode": "0755", "owner": "root", "size": 2474824, "src": "/opt/firecracker/firecracker-v1.13.1-aarch64.debug", "state": "file", "uid": 0}
```
<img width="1508" height="594" alt="Screenshot 2025-10-26 at 7 10 53 PM" src="https://github.com/user-attachments/assets/249c8205-ea96-453d-8750-e47f6edf4707" />

This would cause later check to fail:

```
TASK [Check Firecracker version] ***********************************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": ["/usr/local/bin/firecracker", "--version"], "delta": "0:00:00.050786", "end": "2025-10-26 22:11:02.464905", "msg": "non-zero return code", "rc": -4, "start": "2025-10-26 22:11:02.414119", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```